### PR TITLE
Make submodules core and dir_entry public.

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,4 @@
-mod dir_entry;
+pub mod dir_entry;
 mod dir_entry_iter;
 mod index_path;
 mod ordered;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //! # }
 //! ```
 
-mod core;
+pub mod core;
 
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use std::cmp::Ordering;


### PR DESCRIPTION
Would be useful to have access to submodule dir_entry. Is needed when using the walkdir results in a function like:

`fn foo(entry: &std::result::Result<jwalk::core::dir_entry::DirEntry<()>, std::io::Error>) {
...`
