### PR TITLE
Add parallel recursive descent as reference

### DIFF
--- a/benches/walk_benchmark.rs
+++ b/benches/walk_benchmark.rs
@@ -34,30 +34,50 @@ fn checkout_linux_if_needed() {
 
 #[derive(Default)]
 struct FsTree {
-    path: PathBuf,
     children: Vec<FsTree>,
+    metadata: Option<std::fs::Metadata>,
 }
 
 impl FsTree {
-    fn recursive_descent(root: impl AsRef<Path>, file_type: Option<std::fs::FileType>) -> Self {
+    fn recursive_descent(
+        root: impl AsRef<Path>,
+        file_type: Option<std::fs::FileType>,
+        get_file_metadata: bool,
+    ) -> Self {
         let root = root.as_ref();
-        let is_dir = file_type
-            .map(|ft| ft.is_dir())
+        let (metadata, is_dir) = file_type
+            .map(|ft| {
+                (
+                    if !ft.is_dir() && get_file_metadata {
+                        std::fs::symlink_metadata(root).ok()
+                    } else {
+                        None
+                    },
+                    ft.is_dir(),
+                )
+            })
             .or_else(|| {
                 std::fs::symlink_metadata(root)
-                    .map(|m| m.file_type().is_dir())
+                    .map(|m| {
+                        let is_dir = m.file_type().is_dir();
+                        (Some(m), is_dir)
+                    })
                     .ok()
             })
-            .unwrap_or(false);
+            .unwrap_or((None, false));
 
         let children: Vec<_> = if is_dir {
             std::fs::read_dir(root)
                 .map(|iter| {
-                    let entries = iter.filter_map(Result::ok).collect::<Vec<_>>();
-                    entries
+                    iter.filter_map(Result::ok)
+                        .collect::<Vec<_>>()
                         .into_par_iter()
                         .map(|entry| {
-                            FsTree::recursive_descent(entry.path(), entry.file_type().ok())
+                            FsTree::recursive_descent(
+                                entry.path(),
+                                entry.file_type().ok(),
+                                get_file_metadata,
+                            )
                         })
                         .collect()
                 })
@@ -65,19 +85,22 @@ impl FsTree {
         } else {
             Vec::new()
         };
-        FsTree {
-            children,
-            path: root.to_owned(),
-        }
+        FsTree { children, metadata }
     }
 }
 
 fn walk_benches(c: &mut Criterion) {
     checkout_linux_if_needed();
 
-    c.bench_function("simple recursive (unsorted, n threads)", |b| {
-        b.iter(|| black_box(FsTree::recursive_descent(linux_dir(), None)))
-    });
+    c.bench_function(
+        "simple recursive NO file metadata (unsorted, n threads)",
+        |b| b.iter(|| black_box(FsTree::recursive_descent(linux_dir(), None, false))),
+    );
+
+    c.bench_function(
+        "simple recursive WITH file metadata (unsorted, n threads)",
+        |b| b.iter(|| black_box(FsTree::recursive_descent(linux_dir(), None, true))),
+    );
 
     c.bench_function("jwalk (unsorted, n threads)", |b| {
         b.iter(|| for _ in WalkDir::new(linux_dir()) {})


### PR DESCRIPTION
There are some benefits of having it as a baseline.

* minimal overhead to the traversal, using only rayon `into_par_iter()` and allocations are reduced to a minimum
* a second run does not minimize metadata calls to capture the performance that typical users of jwalk might see

The benchmarks show that it is marginally faster on the linux kernel, even though I am not sure if its statistically significant. `criterion` might assure that though.

Related to #30. 